### PR TITLE
rename edges subcommand to nodes

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/fabedge/fabctl/pkg/cmd/cert"
 	"github.com/fabedge/fabctl/pkg/cmd/clusterinfo"
-	"github.com/fabedge/fabctl/pkg/cmd/edges"
 	"github.com/fabedge/fabctl/pkg/cmd/images"
+	"github.com/fabedge/fabctl/pkg/cmd/nodes"
 	"github.com/fabedge/fabctl/pkg/cmd/ping"
 	"github.com/fabedge/fabctl/pkg/cmd/swanctl"
 	"github.com/fabedge/fabctl/pkg/cmd/topology"
@@ -25,7 +25,7 @@ func New() *cobra.Command {
 	cmd.AddCommand(clusterinfo.New(clientFactory))
 	cmd.AddCommand(ping.New(clientFactory))
 	cmd.AddCommand(images.New(clientFactory))
-	cmd.AddCommand(edges.New(clientFactory))
+	cmd.AddCommand(nodes.New(clientFactory))
 	cmd.AddCommand(swanctl.New(clientFactory))
 	cmd.AddCommand(topology.New(clientFactory))
 	cmd.AddCommand(cert.New(clientFactory))

--- a/pkg/cmd/topology/topology.go
+++ b/pkg/cmd/topology/topology.go
@@ -36,7 +36,7 @@ fabctl topology -l dot -o dot network.dot
 			util.CheckError(cluster.ExtractArgumentsFromFabEdge())
 			util.CheckError(cluster.LoadCommunities())
 
-			edgeNodes, err := cli.ListEdgeNodes(context.Background(), cluster.EdgeLabels)
+			edgeNodes, err := cli.ListNodes(context.Background(), cluster.EdgeLabels)
 			util.CheckError(err)
 
 			clusters, err := cli.ListClusters(context.Background())

--- a/pkg/types/client.go
+++ b/pkg/types/client.go
@@ -55,7 +55,7 @@ func (c Client) ListAllCommunities(ctx context.Context) ([]apisv1.Community, err
 	return communities.Items, err
 }
 
-func (c Client) ListEdgeNodes(ctx context.Context, labels client.MatchingLabels) ([]corev1.Node, error) {
+func (c Client) ListNodes(ctx context.Context, labels client.MatchingLabels) ([]corev1.Node, error) {
 	var nodes corev1.NodeList
 	err := c.List(ctx, &nodes, labels)
 	return nodes.Items, err


### PR DESCRIPTION
It's more useful to show information of nodes filtered by query.

Signed-off-by: yanjianbo <yanjianbo@beyondcent.com>